### PR TITLE
Fixes destination path for .git folder in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY package.json /root
 COPY package-lock.json /root
 COPY test /root/test
 COPY lib /root/lib
-COPY .git /.git
+COPY .git /root/.git
 
 # Install as public random person
 RUN npm i --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,19 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN npm i -g npm@latest
 
-WORKDIR /root/
+WORKDIR /root/app/
 
-COPY .eslintrc /root
-COPY .gintrc /root
-COPY scripts /root/scripts
-COPY package.json /root
-COPY package-lock.json /root
-COPY test /root/test
-COPY lib /root/lib
-COPY .git /root/.git
+COPY .eslintrc .
+COPY .gintrc .
+COPY scripts ./scripts
+COPY package.json .
+COPY package-lock.json .
+COPY test ./test
+COPY lib ./lib
+COPY .git ./.git
 
 # Install as public random person
 RUN npm i --quiet
 
 # Steps needs to use token to Publish, so let it know to use npm as NPM_TOKEN_AHM
-COPY .npmrc /root
+COPY .npmrc .


### PR DESCRIPTION
Inspired by @kkortchinska [PR](https://github.com/ahmdigital/ahm-constants/pull/474) found another repo that has the same issue, this PR fixes the destination path of the .git folder when copied into the docker image.

This PR also updates the working directory inside the docker image to `/root/app/`. We are using the path /root/app/ as docker runs as root by default and we are creating a new folder app in the home directory of the root user to ensure a clean workspace for the build.