### PR TITLE
[patch] Resolve version clash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahmdigital/config",
-  "version": "7.2.3-1",
+  "version": "7.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahmdigital/config",
-  "version": "7.2.3-1",
+  "version": "7.2.3",
   "description": "",
   "author": "ahm",
   "license": "UNLICENSED",


### PR DESCRIPTION
Resolving this version clash:
 
![image](https://user-images.githubusercontent.com/24376125/95708725-b4113e00-0ca8-11eb-88c6-1aadc8db7497.png)

for some reason we had prerelease version in master which resulted in version clash in codeship pipeline.
