### PR TITLE
[patch] Fixing jq: command not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /root/app/
 ENV TZ=Australia/Melbourne
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+RUN apt-get update \
+    && apt-get install -y jq
+
 RUN npm i -g npm@latest
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
Fixes failing build by installing jq:

![image](https://user-images.githubusercontent.com/24376125/95709642-cd1aee80-0caa-11eb-9a08-cfcc1b764051.png)
https://app.codeship.com/projects/600024b0-a3d0-0134-63f0-26c19bdf8358/builds/e631cc78-a48e-4f37-8060-fb7532e454c3?component=step_Authenticate_and_release&log=588dee7d-2f4c-4c12-8756-446182b502f1_134